### PR TITLE
fix: 修复缩略图路径前缀重复的问题

### DIFF
--- a/app/FileStorage/Filesystems/LocalFilesystem.php
+++ b/app/FileStorage/Filesystems/LocalFilesystem.php
@@ -95,7 +95,7 @@ class LocalFilesystem implements FilesystemInterface
                 return $this->filesystem->response($resource->getPath());
             }
 
-            $pathinfo = \League\Flysystem\Util::pathinfo($realPath);
+            $pathinfo = \League\Flysystem\Util::pathinfo($resource->getPath());
             $cachePath = sprintf('%s/%s/%s.%s', $pathinfo['dirname'], $pathinfo['filename'], $rule->getFilename(), $pathinfo['extension']);
             if ($this->filesystem->has($cachePath)) {
                 return $this->filesystem->response($cachePath);


### PR DESCRIPTION
目前缩略图路径有问题， 假设 文件文件存储路径为 /www/site/storage/app
实际缩略图保存路径会是： /www/site/storage/app/www/site/storage/app/YYYY/MM/DD/xxx/xxx.jpeg
并且导致windows下无法创建目录和生成缩略图，因此无法访问图片